### PR TITLE
Delete group

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "start": "node",
     "dev": "nodemon ./src/server.ts",
     "migrate": "cross-env NODE_ENV=test ./node_modules/.bin/sequelize db:migrate",
+    "seed": "cross-env NODE_ENV=test ./node_modules/.bin/sequelize db:seed:all",
     "undomigrate": "cross-env NODE_ENV=test ./node_modules/.bin/sequelize db:migrate:undo:all",
-    "migrate:test": "cross-env NODE_ENV=test npm run undomigrate && npm run migrate && npm run test"
+    "migrate:test": "cross-env NODE_ENV=test npm run undomigrate && npm run migrate && npm run seed && npm run test"
   },
   "keywords": [],
   "author": "",

--- a/src/controllers/GroupController.ts
+++ b/src/controllers/GroupController.ts
@@ -56,4 +56,27 @@ export class GroupController {
 
     return ok(res, group);
   };
+
+  /**
+   * Deletes a user group
+   *
+   * @param {Request} req
+   * @param {Response} res
+   * @param {(error: Error) => {}} next
+   * @returns
+   *
+   * @memberOf ChatController
+   */
+  public delete = async (req: Request, res: Response, next: (error) => {}) => {
+    const [result, error] = await this.groupRepo.delete(req);
+
+    if (error) {
+      if (error.status === NOT_FOUND) return notFound(res, error.message);
+      if (error.status === UNAUTHORIZED)
+        return unauthorised(res, error.message);
+      return next(error);
+    }
+
+    return ok(res, { message: result.message });
+  };
 }

--- a/src/repositories/GroupRepository.ts
+++ b/src/repositories/GroupRepository.ts
@@ -1,4 +1,5 @@
-import { NOT_FOUND, UNAUTHORIZED } from 'http-status-codes';
+import { Request } from 'express';
+import { NOT_FOUND, UNAUTHORIZED, OK } from 'http-status-codes';
 import { Group } from '../models/index';
 
 export class GroupRepository {
@@ -45,6 +46,42 @@ export class GroupRepository {
           {
             status: UNAUTHORIZED,
             message: 'Not authorised to update this group',
+          },
+        ];
+      }
+      return [null, { status: NOT_FOUND, message: 'Group not found' }];
+    } catch (error) {
+      return [null, error];
+    }
+  }
+
+  /**
+   * Deletes a user's group
+   *
+   * @param {Request} req
+   * @returns
+   *
+   * @memberOf GroupRepository
+   */
+  public async delete(req: Request) {
+    try {
+      const group = await Group.findByPk(req.params.goupId);
+      if (group) {
+        if (group.user_id === req['user'].id) {
+          group.destroy();
+          return [
+            {
+              status: OK,
+              message: 'Group deleted',
+            },
+            null,
+          ];
+        }
+        return [
+          null,
+          {
+            status: UNAUTHORIZED,
+            message: 'Not authorised to delete this group',
           },
         ];
       }

--- a/src/routes/group.ts
+++ b/src/routes/group.ts
@@ -5,12 +5,16 @@ import { auth } from '../middlewares/auth';
 
 const groupRoutes = Router();
 const groupController = new GroupController();
-const { updateGroupValidationResult, createGroupValidator } = groupValidation;
+const {
+  updateGroupValidationResult,
+  createGroupValidator,
+  createGroupValidationResult,
+} = groupValidation;
 
 groupRoutes.post(
   '/',
   createGroupValidator,
-  updateGroupValidationResult,
+  createGroupValidationResult,
   groupController.create
 );
 
@@ -20,5 +24,7 @@ groupRoutes.put(
   updateGroupValidationResult,
   groupController.update
 );
+
+groupRoutes.delete('/:goupId', groupController.delete);
 
 export default groupRoutes;

--- a/test/feature/group.spec.ts
+++ b/test/feature/group.spec.ts
@@ -49,7 +49,7 @@ describe('Group Controller', () => {
       request
         .post('/api/v1/groups')
         .set({ authorization: token })
-        .send({ ...group, name: 'ty' })
+        .send({ ...group, name })
         .expect(422)
         .end((err, res) => {
           const { message } = res.body;
@@ -133,6 +133,45 @@ describe('Group Controller', () => {
           const { body } = res;
           if (err) return done(err);
           expect(body.message).to.equal('invalid token');
+          done();
+        });
+    });
+  });
+
+  describe('Delete Group PUT: /api/v1/groups/:goupId', () => {
+    it('should successfully delete a group', (done) => {
+      request
+        .delete('/api/v1/groups/1')
+        .set({ authorization: token })
+        .expect(200)
+        .end((err, res) => {
+          const { body } = res.body;
+          if (err) return done(err);
+          expect(body.message).to.equal('Group deleted');
+          done();
+        });
+    });
+    it('should return 401 if group does not belong to current user', (done) => {
+      request
+        .delete('/api/v1/groups/2')
+        .set({ authorization: token })
+        .expect(401)
+        .end((err, res) => {
+          const { body } = res;
+          if (err) return done(err);
+          expect(body.message).to.equal('Not authorised to delete this group');
+          done();
+        });
+    });
+    it('should return 404 if group does not exist', (done) => {
+      request
+        .delete('/api/v1/groups/2987')
+        .set({ authorization: token })
+        .expect(404)
+        .end((err, res) => {
+          const { body } = res;
+          if (err) return done(err);
+          expect(body.message).to.equal('Group not found');
           done();
         });
     });


### PR DESCRIPTION
##### What does this PR do?
This task allows registered users to delete their groups.

##### Description of tasks completed
- Delete group

##### How can this be tested?
- Make a DELETE request to /api/v1/groups/:id with a group id of the current user.
- Expected response
-- 200 success with response body `{
    "status_code": 200,
    "body": {
        "message": "Group deleted"
    }
}`
-- 404 group not found  with body `{
    "status_code": 404,
    "message": "Group not found"
}`
-- 401 error with response body of if the group does not belong to current user`{
    "status_code": 401,
    "message": "Not authorized to update this group"
}`
-- 500 error with body `{
    "message": "invalid token",
    "stack": "JsonWebTokenError: invalid token\n .... }`

##### Autometed testing?
- Run `npm run test`
