### PR TITLE
Add user to group

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 .env
 .nyc_output
 coverage
+
+**/*/.DS_Store

--- a/src/controllers/GroupController.ts
+++ b/src/controllers/GroupController.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express';
-import { NOT_FOUND, UNAUTHORIZED } from 'http-status-codes';
+import { NOT_FOUND, UNAUTHORIZED, CONFLICT } from 'http-status-codes';
 import { GroupRepository } from '../repositories/GroupRepository';
-import { created, ok } from '../helpers/response';
+import { created, ok, conflict } from '../helpers/response';
 import { notFound, unauthorised } from '../helpers/response';
 
 export class GroupController {
@@ -78,5 +78,30 @@ export class GroupController {
     }
 
     return ok(res, { message: result.message });
+  };
+
+  /**
+   * Adds a user to a group
+   *
+   * @param {Request} req
+   * @param {Response} res
+   * @param {(error: Error) => {}} next
+   * @returns
+   *
+   * @memberOf ChatController
+   */
+  public addUser = async (req: Request, res: Response, next: (error) => {}) => {
+    const [userGroup, error] = await this.groupRepo.addUser(req);
+    if (error) {
+      if (error.status === NOT_FOUND) return notFound(res, error.message);
+      if (error.status === UNAUTHORIZED) {
+        return unauthorised(res, error.message);
+      }
+      if (error.status === CONFLICT) {
+        return conflict(res, error.message);
+      }
+      return next(error);
+    }
+    return created(res, await userGroup);
   };
 }

--- a/src/database/migrations/20200730011913-user_groups.js
+++ b/src/database/migrations/20200730011913-user_groups.js
@@ -1,0 +1,23 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('UserGroups', {
+      id: Sequelize.INTEGER,
+      UserId: Sequelize.INTEGER,
+      GroupId: Sequelize.INTEGER,
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('UserGroups');
+  },
+};

--- a/src/middlewares/error.ts
+++ b/src/middlewares/error.ts
@@ -27,7 +27,16 @@ export const errorHandler = (
   res: Response,
   next: any
 ) => {
-  const statusCode = res.statusCode === 200 ? 500 : res.statusCode || 500;
+  let statusCode: number;
+
+  if (err['statusCode']) {
+    statusCode = err['statusCode'];
+  } else if (res.statusCode && res.statusCode === 200) {
+    statusCode = 500;
+  } else {
+    statusCode = res.statusCode || 500;
+  }
+
   res.status(statusCode);
   res.json({
     message: err.message,

--- a/src/middlewares/validation/groupValidation.ts
+++ b/src/middlewares/validation/groupValidation.ts
@@ -42,12 +42,12 @@ export const groupValidation = {
   ) => {
     const { name } = req.body;
     const { id } = req['user'];
-    const { goupId } = req.params;
+    const { groupId } = req.params;
     const result = validationResult(req);
 
     if (!result.isEmpty()) return unporecessed(res, result.array());
 
-    req.body = { name, user_id: id, id: goupId };
+    req.body = { name, user_id: id, id: groupId };
 
     return next();
   },

--- a/src/models/Group.ts
+++ b/src/models/Group.ts
@@ -1,5 +1,6 @@
 import { Model, DataTypes } from 'sequelize';
 import { dbInstance } from '../database/db';
+import { User } from './User';
 
 export class Group extends Model {
   public id?: number;
@@ -7,6 +8,9 @@ export class Group extends Model {
   public user_id: number;
   public readonly createdAt?: string;
   public readonly updatedAt?: string;
+
+  public addUsers: (user: User) => {};
+  public getUsers: () => User[];
 }
 Group.init(
   {

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -14,6 +14,8 @@ export class User extends Model {
   public password: string;
   public readonly createdAt?: string;
   public readonly updatedAt?: string;
+
+  public getGroups: () => Group[];
 }
 User.init(
   {

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -6,13 +6,7 @@ import { User } from './User';
  * User group relationship, to prevent circle dependency
  * ***************
  */
-User.hasMany(Group, {
-  sourceKey: 'id',
-  foreignKey: 'user_id',
-});
-Group.belongsTo(User, {
-  targetKey: 'id',
-  foreignKey: 'user_id',
-});
+User.belongsToMany(Group, { through: 'UserGroups' });
+Group.belongsToMany(User, { through: 'UserGroups' });
 
 export { Group, User };

--- a/src/repositories/GroupRepository.ts
+++ b/src/repositories/GroupRepository.ts
@@ -1,6 +1,7 @@
 import { Request } from 'express';
-import { NOT_FOUND, UNAUTHORIZED, OK } from 'http-status-codes';
-import { Group } from '../models/index';
+import { NOT_FOUND, UNAUTHORIZED, OK, CONFLICT } from 'http-status-codes';
+import { Group, User } from '../models/index';
+import { exists } from 'fs';
 
 export class GroupRepository {
   constructor() {}
@@ -65,7 +66,7 @@ export class GroupRepository {
    */
   public async delete(req: Request) {
     try {
-      const group = await Group.findByPk(req.params.goupId);
+      const group = await Group.findByPk(req.params.groupId);
       if (group) {
         if (group.user_id === req['user'].id) {
           group.destroy();
@@ -82,6 +83,70 @@ export class GroupRepository {
           {
             status: UNAUTHORIZED,
             message: 'Not authorised to delete this group',
+          },
+        ];
+      }
+      return [null, { status: NOT_FOUND, message: 'Group not found' }];
+    } catch (error) {
+      return [null, error];
+    }
+  }
+
+  /**
+   * Adds users to groups
+   *
+   * @param {Request} req
+   * @returns
+   *
+   * @memberOf GroupRepository
+   */
+  public async addUser(req: Request) {
+    try {
+      const { groupId, id } = req.params;
+      const group = await Group.findByPk(groupId);
+
+      if (group) {
+        if (group.user_id !== req['user'].id)
+          return [
+            null,
+            {
+              status: UNAUTHORIZED,
+              message: 'Not authorised',
+            },
+          ];
+
+        if (req['user'].id === parseInt(id))
+          return [
+            null,
+            {
+              status: CONFLICT,
+              message: 'Cannot add group admin to group',
+            },
+          ];
+
+        const users = await group.getUsers();
+        const exists = users.find((user) => user.id === parseInt(id));
+
+        if (exists)
+          return [
+            null,
+            {
+              status: CONFLICT,
+              message: 'User alread a member of this group',
+            },
+          ];
+
+        const user = await User.findByPk(id);
+
+        if (user) {
+          group.addUsers(user);
+          return [{ message: 'User added to group' }, null];
+        }
+        return [
+          null,
+          {
+            status: NOT_FOUND,
+            message: 'User not found',
           },
         ];
       }

--- a/src/routes/group.ts
+++ b/src/routes/group.ts
@@ -19,12 +19,13 @@ groupRoutes.post(
 );
 
 groupRoutes.put(
-  '/:goupId',
+  '/:groupId',
   createGroupValidator,
   updateGroupValidationResult,
   groupController.update
 );
 
-groupRoutes.delete('/:goupId', groupController.delete);
+groupRoutes.delete('/:groupId', groupController.delete);
+groupRoutes.post('/:groupId/add-user/:id', groupController.addUser);
 
 export default groupRoutes;

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import { Socket } from './socket';
 import { dbInstance } from './database/db';
 import Event from './events/Event';
 
-const port: number = Number(process.env.PORT) || 3001;
+const port: number = parseInt(process.env.PORT, 10) || 3001;
 const event = new Event().listen();
 const app: App = new App();
 global['eventEmitter'] = event.getEventEmitter();

--- a/test/feature/index.spec.ts
+++ b/test/feature/index.spec.ts
@@ -19,3 +19,20 @@ describe('Test 404 handler', () => {
       });
   });
 });
+
+describe('Test / route', () => {
+  it('should return a 200 success', (done) => {
+    const doc = process.env.DOCURL;
+    request
+      .get('/')
+      .expect(200)
+      .end((err, res) => {
+        const { body } = res;
+        if (err) return done(err);
+        expect(body.message).to
+          .equal(`Welcome to the meetup API, please consult \
+        the API documentatuon for more info on ${doc}`);
+        done();
+      });
+  });
+});

--- a/test/feature/user.spec.ts
+++ b/test/feature/user.spec.ts
@@ -10,10 +10,6 @@ const expect = chai.expect;
 const request = supertest(new App().getApp());
 
 before((done) => {
-  User.destroy({
-    where: {},
-    truncate: true,
-  });
   global['eventEmitter'] = {
     emit: (name, data) => {},
   };


### PR DESCRIPTION
##### What does this PR do?
This task allows group owners to add users to their groups.

##### Description of tasks completed
- Add users to group

##### How can this be tested?
- Make a POST request to localhost:4000/api/v1/groups/groupId/add-user/id with a group id of the current user and the id of the user to be added to the group.
- Expected response
-- 200 success with response body `{
    "status_code": 201,
    "body": {
        "message": "User added to group"
    }
}`
-- 404 group not found  if groupId does not exist on the database with body `{
    "status_code": 404,
    "message": "Group not found"
}`
-- 404 user not found  if user id is not a registered user with body `{
    "status_code": 404,
    "message": "User not found"
}`
-- 401 error with response body of if the group does not belong to current user`{
    "status_code": 401,
    "message": "Not authorized"
}`

-- 401 error with response body of if the group does not belong to current user`{
    "status_code": 401,
    "message": "Not authorized"
}`

-- 409 error if user already a member of the group with response body `{
    "status_code": 409,
    "message": "User already a member of this group"
}}`


##### Autometed testing?
- Run `npm run test`
