### PR TITLE
Remove users from groups

### DIFF
--- a/src/controllers/GroupController.ts
+++ b/src/controllers/GroupController.ts
@@ -33,7 +33,7 @@ export class GroupController {
 
   /**
    * Updates a user group
-   *
+   *+
    * @param {Request} req
    * @param {Response} res
    * @param {(error: Error) => {}} next
@@ -80,5 +80,26 @@ export class GroupController {
     if (error) return next(error);
 
     return created(res, await userGroup);
+  };
+
+  /**
+   * Removes a user from a group
+   *
+   * @param {Request} req
+   * @param {Response} res
+   * @param {(error: Error) => {}} next
+   * @returns
+   *
+   * @memberOf ChatController
+   */
+  public removeUser = async (
+    req: Request,
+    res: Response,
+    next: (error) => {}
+  ) => {
+    const [userGroup, error] = await this.groupRepo.removeUser(req);
+    if (error) return next(error);
+
+    return ok(res, await userGroup);
   };
 }

--- a/src/models/Group.ts
+++ b/src/models/Group.ts
@@ -11,6 +11,7 @@ export class Group extends Model {
 
   public addUsers: (user: User) => {};
   public getUsers: () => User[];
+  public removeUser: (user: User) => {};
 }
 Group.init(
   {

--- a/src/repositories/GroupRepository.ts
+++ b/src/repositories/GroupRepository.ts
@@ -76,7 +76,7 @@ export class GroupRepository {
   }
 
   /**
-   * Adds users to groups
+   * Performs users to groups database opreation
    *
    * @param {Request} req
    * @returns
@@ -87,24 +87,51 @@ export class GroupRepository {
     try {
       const { groupId, id } = req.params;
       const group = await Group.findByPk(groupId);
-
       if (group) {
         if (group.user_id !== req['user'].id)
           return [null, new Unauthorized('Not authorised')];
 
         const users = await group.getUsers();
         const exists = users.find((user) => user.id === parseInt(id));
-
         if (exists || req['user'].id === parseInt(id))
           return [null, new Conflict('User alread in this group')];
 
         let user: User = await User.findByPk(id);
-
         if (user) {
           group.addUsers(user);
           return [{ message: 'User added to group' }, null];
         }
         return [null, new NotFound('User not found')];
+      }
+      return [null, new NotFound('Group not found')];
+    } catch (error) {
+      return [null, error];
+    }
+  }
+
+  /**
+   * Performs remove user database opreation
+   *
+   * @param {Request} req
+   * @returns
+   *
+   * @memberOf GroupRepository
+   */
+  public async removeUser(req: Request) {
+    try {
+      const { groupId, id } = req.params;
+      const group = await Group.findByPk(groupId);
+      if (group) {
+        if (group.user_id !== req['user'].id)
+          return [null, new Unauthorized('Not authorised')];
+
+        const users = await group.getUsers();
+        const groupUser = users.find((user) => user.id === parseInt(id));
+        if (!groupUser)
+          return [null, new NotFound('User not a member of this this group')];
+
+        group.removeUser(groupUser);
+        return [{ message: 'User removed from group' }, null];
       }
       return [null, new NotFound('Group not found')];
     } catch (error) {

--- a/src/routes/group.ts
+++ b/src/routes/group.ts
@@ -26,6 +26,7 @@ groupRoutes.put(
 );
 
 groupRoutes.delete('/:groupId', groupController.delete);
-groupRoutes.post('/:groupId/add-user/:id', groupController.addUser);
+groupRoutes.post('/:groupId/user/:id', groupController.addUser);
+groupRoutes.delete('/:groupId/user/:id', groupController.removeUser);
 
 export default groupRoutes;

--- a/test/feature/group.spec.ts
+++ b/test/feature/group.spec.ts
@@ -151,7 +151,7 @@ describe('Group Controller', () => {
   describe('Add User to Group POST: api/v1/groups/groupId/add-user/:id', () => {
     it('should successfully add a user to a group', (done) => {
       request
-        .post('/api/v1/groups/1/add-user/2')
+        .post('/api/v1/groups/1/user/2')
         .set({ authorization: token })
         .expect(201)
         .end((err, res) => {
@@ -163,7 +163,7 @@ describe('Group Controller', () => {
     });
     it('should return 409 if user already a member if the group', (done) => {
       request
-        .post('/api/v1/groups/1/add-user/2')
+        .post('/api/v1/groups/1/user/2')
         .set({ authorization: token })
         .expect(409)
         .end((err, res) => {
@@ -175,7 +175,7 @@ describe('Group Controller', () => {
     });
     it('should return 401 if current user is not the owner of the group', (done) => {
       request
-        .post('/api/v1/groups/2/add-user/1')
+        .post('/api/v1/groups/2/user/1')
         .set({ authorization: token })
         .expect(401)
         .end((err, res) => {
@@ -187,7 +187,7 @@ describe('Group Controller', () => {
     });
     it('should return 404 if user already a member if the group', (done) => {
       request
-        .post('/api/v1/groups/1/add-user/187')
+        .post('/api/v1/groups/1/user/187')
         .set({ authorization: token })
         .expect(404)
         .end((err, res) => {
@@ -199,7 +199,7 @@ describe('Group Controller', () => {
     });
     it('should return 409 if user tries to add self', (done) => {
       request
-        .post('/api/v1/groups/1/add-user/1')
+        .post('/api/v1/groups/1/user/1')
         .set({ authorization: token })
         .expect(409)
         .end((err, res) => {
@@ -211,13 +211,63 @@ describe('Group Controller', () => {
     });
     it('should return 404 if group not found', (done) => {
       request
-        .post('/api/v1/groups/1564/add-user/2')
+        .post('/api/v1/groups/1564/user/2')
         .set({ authorization: token })
         .expect(404)
         .end((err, res) => {
           const { body } = res;
           if (err) return done(err);
           expect(body.message).to.equal('Group not found');
+          done();
+        });
+    });
+  });
+  describe('Remove User from Group DELETE: /api/v1/groups/:goupId/user/:id', () => {
+    it('should successfully remove a user from a group', (done) => {
+      request
+        .delete('/api/v1/groups/1/user/2')
+        .set({ authorization: token })
+        .expect(200)
+        .end((err, res) => {
+          const { body } = res.body;
+          if (err) return done(err);
+          expect(body.message).to.equal('User removed from group');
+          done();
+        });
+    });
+    it('should return 401 if current user is not the owner of the group', (done) => {
+      request
+        .delete('/api/v1/groups/2/user/2')
+        .set({ authorization: token })
+        .expect(401)
+        .end((err, res) => {
+          const { message } = res.body;
+          if (err) return done(err);
+          expect(message).to.equal('Not authorised');
+          done();
+        });
+    });
+    it('should return 404 if user is a member of the group', (done) => {
+      request
+        .delete('/api/v1/groups/1/user/254')
+        .set({ authorization: token })
+        .expect(404)
+        .end((err, res) => {
+          const { message } = res.body;
+          if (err) return done(err);
+          expect(message).to.equal('User not a member of this this group');
+          done();
+        });
+    });
+    it('should return 401 if group does not exist', (done) => {
+      request
+        .delete('/api/v1/groups/154/user/2')
+        .set({ authorization: token })
+        .expect(404)
+        .end((err, res) => {
+          const { message } = res.body;
+          if (err) return done(err);
+          expect(message).to.equal('Group not found');
           done();
         });
     });


### PR DESCRIPTION
##### What does this PR do?
This task allows group owners to remove users from their groups.

##### Description of tasks completed
- Remove users from group

##### How can this be tested?
- Make a DELETE request to `/api/v1/groups/:groupId/user/:id` with a group id of the current user and the id of the user to be deleted from the group.
- Expected response
-- 200 success with response body `{
    "status_code": 200,
    "body": {
        "message": "User removed from group"
    }
}`
-- 404 group not found  if groupId does not exist on the database with body `{
    "status_code": 404,
    "message": "Group not found"
}`
-- 404 user not found  if the user id is not a registered user with body `{
    "status_code": 404,
    "message": "User not a member of this group"
}`
-- 401 error with response body of if the group does not belong to current user`{
    "status_code": 401,
    "message": "Not authorized"
}`


##### Autometed testing?
- Run `npm run test`
