### PR TITLE
get a user's groups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1254,6 +1254,12 @@
         "@types/node": "*"
       }
     },
+    "@types/chai": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.12.tgz",
+      "integrity": "sha512-aN5IAC8QNtSUdQzxu7lGBgYAOuU1tmRU4c9dIq5OKGf/SBVjXo+ffM2wEjudAWbgpOhy60nLoAGH1xm8fpCKFQ==",
+      "dev": true
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@babel/preset-typescript": "^7.10.4",
     "@babel/register": "^7.10.5",
     "@types/bcryptjs": "^2.4.2",
+    "@types/chai": "^4.2.12",
     "@types/express": "^4.17.7",
     "@types/faker": "^4.1.12",
     "@types/glob": "^7.1.3",

--- a/src/controllers/GroupController.ts
+++ b/src/controllers/GroupController.ts
@@ -102,4 +102,25 @@ export class GroupController {
 
     return ok(res, await userGroup);
   };
+
+  /**
+   * Gets a user's groups
+   *
+   * @param {Request} req
+   * @param {Response} res
+   * @param {(error: Error) => {}} next
+   * @returns
+   *
+   * @memberOf ChatController
+   */
+  public getMyGroups = async (
+    req: Request,
+    res: Response,
+    next: (error) => {}
+  ) => {
+    const [userGroup, error] = await this.groupRepo.getMyGroups(req);
+    if (error) return next(error);
+
+    return ok(res, await userGroup);
+  };
 }

--- a/src/database/seeders/20200728213540-user.js
+++ b/src/database/seeders/20200728213540-user.js
@@ -4,7 +4,7 @@ const faker = require('faker');
 module.exports = {
   up: (queryInterface, Sequelize) => {
     const data = [];
-    const amountToSeed = 5;
+    const amountToSeed = 7;
     let count = 0;
 
     while (count < amountToSeed) {

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -19,9 +19,10 @@ export const auth = async (req: Request, res: Response, next) => {
 
   const [decoded, error] = await decode(token);
   if (error) return next(error);
-  // const user = await verifyUser(decoded.id);
+  const user = await verifyUser(decoded.id);
+  if (!user) return next(new Unauthorized('Unauthorized Access'));
 
-  req['user'] = decoded;
+  req['user'] = user;
   return next();
 };
 
@@ -32,6 +33,6 @@ export const auth = async (req: Request, res: Response, next) => {
  *
  * @returns {User}
  */
-// export const verifyUser = async (userId: number) => {
-//   return await User.findByPk(userId);
-// };
+export const verifyUser = async (userId: number) => {
+  return await User.findByPk(userId);
+};

--- a/src/repositories/GroupRepository.ts
+++ b/src/repositories/GroupRepository.ts
@@ -138,4 +138,33 @@ export class GroupRepository {
       return [null, error];
     }
   }
+
+  /**
+   * Perform database operation to get a user's group
+   *
+   * @param {Request} req
+   * @returns
+   *
+   * @memberOf GroupRepository
+   */
+  public async getMyGroups(req: Request) {
+    try {
+      const user = req['user'];
+      const groupsAdded = await user.getGroups();
+      const groupsCreated = await Group.findAll({
+        where: { user_id: user.id },
+      });
+
+      const groups = [...groupsAdded, ...groupsCreated];
+      if (groups.length === 0)
+        return [
+          null,
+          new NotFound('User has not created or added to to a group!!'),
+        ];
+
+      return [groups, null];
+    } catch (error) {
+      return [null, error];
+    }
+  }
 }

--- a/src/routes/group.ts
+++ b/src/routes/group.ts
@@ -28,5 +28,6 @@ groupRoutes.put(
 groupRoutes.delete('/:groupId', groupController.delete);
 groupRoutes.post('/:groupId/user/:id', groupController.addUser);
 groupRoutes.delete('/:groupId/user/:id', groupController.removeUser);
+groupRoutes.get('/', groupController.getMyGroups);
 
 export default groupRoutes;

--- a/test/data.ts
+++ b/test/data.ts
@@ -21,7 +21,7 @@ export const validUser1 = {
 };
 
 export const invalidEmail = {
-  id: 3,
+  id: 6,
   username: 'james',
   firstName: 'James',
   lastName: 'Gosling',

--- a/test/feature/group.spec.ts
+++ b/test/feature/group.spec.ts
@@ -1,7 +1,7 @@
 import chai from 'chai';
 import supertest from 'supertest';
 import App from '../../src/app';
-import { validUser, validUser1, invalidToken } from '../data';
+import { validUser, validUser1, invalidEmail, invalidToken } from '../data';
 import { encode } from '../../src/helpers/jwt';
 
 const expect = chai.expect;
@@ -17,7 +17,7 @@ before(async (done) => {
     if (err) return done(err);
     token = tkn;
   });
-  encode(validUser1).then((result) => {
+  encode(invalidEmail).then((result) => {
     const [tkn, err] = result;
     if (err) return done(err);
     token1 = tkn;
@@ -222,6 +222,36 @@ describe('Group Controller', () => {
         });
     });
   });
+
+  describe('Gets User from Group GET: /api/v1/groups', () => {
+    it("should successfully gets a user's group", (done) => {
+      request
+        .get('/api/v1/groups')
+        .set({ authorization: token })
+        .expect(200)
+        .end((err, res) => {
+          const { body } = res.body;
+          if (err) return done(err);
+          expect(body.length).to.gt(0);
+          done();
+        });
+    });
+    it('should return 404 if current user not no group nor added to one', (done) => {
+      request
+        .get('/api/v1/groups')
+        .set({ authorization: token1 })
+        .expect(404)
+        .end((err, res) => {
+          const { message } = res.body;
+          if (err) return done(err);
+          expect(message).to.equal(
+            'User has not created or added to to a group!!'
+          );
+          done();
+        });
+    });
+  });
+
   describe('Remove User from Group DELETE: /api/v1/groups/:goupId/user/:id', () => {
     it('should successfully remove a user from a group', (done) => {
       request


### PR DESCRIPTION
##### What does this PR do?
This task allows a user to get his list of groups.

##### Description of tasks completed
- Get a user's list of groups

##### How can this be tested?
- Make a GET request to `/api/v1/groups`.
- Expected response
-- 200 success with response body `{
    "status_code": 200,
    "body": [
        {
            "id": 6,
            "name": "trying times",
            "user_id": 6,
            "createdAt": "2020-07-29T16:46:27.780Z",
            "updatedAt": "2020-07-29T16:46:27.780Z"
        },
        {
            "id": 8,
            "name": "try me na",
            "user_id": 6,
            "createdAt": "2020-07-31T00:14:53.926Z",
            "updatedAt": "2020-07-31T00:14:53.926Z"
        },
    ]
}`
-- 404 groups not found  if groupId does not exist on the database with response body `{
    "status_code": 404,
    "message": "User has not created or added to a group!!"
}`


##### Autometed testing?
- Run `npm run test`
